### PR TITLE
Fix printing of reflect.Float32 kind

### DIFF
--- a/printers.go
+++ b/printers.go
@@ -187,7 +187,7 @@ func PrintValue(w io.Writer, v reflect.Value) (int, error) {
 		return PrintUint(w, v.Uint())
 	}
 
-	if k == reflect.Float64 || k == reflect.Float64 {
+	if k == reflect.Float64 || k == reflect.Float32 {
 		return PrintFloat(w, v.Float())
 	}
 


### PR DESCRIPTION
The clause was `if k == reflect.Float64 || k == reflect.Float64 {` which has the same comparison on both sides and looks like a copy'n'paste error.